### PR TITLE
Travis build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
 before_script:
     # Not using code coverage
   - phpenv config-rm xdebug.ini
+  # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
+  - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
   - if ! [ -z "$MONGO_VERSION" ]; then yes '' | pecl -q install -f mongo-${MONGO_VERSION}; fi
   - if ! [ -z "$MONGODB_VERSION" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi
   - if ! [ -z "$ADAPTER_VERSION" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 
 matrix:
   include:
+    # Test the latest
     - php: 5.6
       env: MONGO_VERSION=stable
     - php: 7.1
@@ -14,16 +15,25 @@ matrix:
     - php: 7.2
       env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
 
+    # Test with the lowest deps
+    - php: 5.6
+      env: MONGO_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+    - php: 7.1
+      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+    - php: 7.2
+      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+
+services: mongodb
 services: mongodb
 
 before_script:
-# Not using code coverage
+    # Not using code coverage
   - phpenv config-rm xdebug.ini
   - if [ "x${MONGO_VERSION}" != "x" ]; then yes '' | pecl -q install -f mongo-${MONGO_VERSION}; fi
   - if [ "x${MONGODB_VERSION}" != "x" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi
   - if [ "x${ADAPTER_VERSION}" != "x" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
   - composer self-update
-  - composer install -v
+  - composer update -v ${COMPOSER_FLAGS}
 
 script:
   - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ matrix:
     # Test with the lowest deps
     - php: 5.6
       env: MONGO_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
-    - php: 7.1
-      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
     - php: 7.2
       env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,4 @@ before_script:
   - composer update -v ${COMPOSER_FLAGS}
 
 script:
-  - ls -l
   - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
 services: mongodb
 
 before_script:
+# Not using code coverage
+  - phpenv config-rm xdebug.ini
   - if [ "x${MONGO_VERSION}" != "x" ]; then yes '' | pecl -q install -f mongo-${MONGO_VERSION}; fi
   - if [ "x${MONGODB_VERSION}" != "x" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi
   - if [ "x${ADAPTER_VERSION}" != "x" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
     # Not using code coverage
   - phpenv config-rm xdebug.ini
   # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
-  - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
+  - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --ignore-platform-reqs --quiet; fi
   - if ! [ -z "$MONGO_VERSION" ]; then yes '' | pecl -q install -f mongo-${MONGO_VERSION}; fi
   - if ! [ -z "$MONGODB_VERSION" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi
   - if ! [ -z "$ADAPTER_VERSION" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - if [ "x${MONGODB_VERSION}" != "x" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi
   - if [ "x${ADAPTER_VERSION}" != "x" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
   - composer self-update
-  - composer install --dev
+  - composer install -v
 
 script:
   - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       env: MONGO_VERSION=stable
     - php: 7.1
       env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
+    - php: 7.2
+      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable
 
 services: mongodb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
-sudo: false
 language: php
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ matrix:
 before_script:
     # Not using code coverage
   - phpenv config-rm xdebug.ini
-  - if [ "x${MONGO_VERSION}" != "x" ]; then yes '' | pecl -q install -f mongo-${MONGO_VERSION}; fi
-  - if [ "x${MONGODB_VERSION}" != "x" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi
-  - if [ "x${ADAPTER_VERSION}" != "x" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
+  - if ! [ -z "$MONGO_VERSION" ]; then yes '' | pecl -q install -f mongo-${MONGO_VERSION}; fi
+  - if ! [ -z "$MONGODB_VERSION" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi
+  - if ! [ -z "$ADAPTER_VERSION" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
   - composer self-update
   - composer update -v ${COMPOSER_FLAGS}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     - php: 5.6
       env: MONGO_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest --prefer-dist"
     - php: 7.2
+    # Note that the ADAPTER_VERSION is pinned to 1.0.0 when testing lowest deps
       env: ADAPTER_VERSION="1.0.0" MONGODB_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest --prefer-dist"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ before_script:
     # Not using code coverage
   - phpenv config-rm xdebug.ini
   # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
-  - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --ignore-platform-reqs --quiet; fi
   - if ! [ -z "$MONGO_VERSION" ]; then yes '' | pecl -q install -f mongo-${MONGO_VERSION}; fi
   - if ! [ -z "$MONGODB_VERSION" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi
   - if ! [ -z "$ADAPTER_VERSION" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
   - composer self-update
+  - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --ignore-platform-reqs --quiet; fi
   - composer update -v ${COMPOSER_FLAGS}
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,5 @@ before_script:
   - composer update -v ${COMPOSER_FLAGS}
 
 script:
+  - ls -l
   - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ matrix:
 
     # Test with the lowest deps
     - php: 5.6
-      env: MONGO_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+      env: MONGO_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest --prefer-dist"
     - php: 7.2
-      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest --prefer-dist"
 
 before_script:
-    # Not using code coverage
+  # Not using code coverage
   - phpenv config-rm xdebug.ini
   - if ! [ -z "$MONGO_VERSION" ]; then yes '' | pecl -q install -f mongo-${MONGO_VERSION}; fi
   - if ! [ -z "$MONGODB_VERSION" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - php: 5.6
       env: MONGO_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest --prefer-dist"
     - php: 7.2
-      env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest --prefer-dist"
+      env: ADAPTER_VERSION="1.0.0" MONGODB_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest --prefer-dist"
 
 before_script:
   # Not using code coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ matrix:
     - php: 7.2
       env: ADAPTER_VERSION="^1.0.0" MONGODB_VERSION=stable COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
 
-services: mongodb
-services: mongodb
-
 before_script:
     # Not using code coverage
   - phpenv config-rm xdebug.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ matrix:
 before_script:
     # Not using code coverage
   - phpenv config-rm xdebug.ini
-  # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
   - if ! [ -z "$MONGO_VERSION" ]; then yes '' | pecl -q install -f mongo-${MONGO_VERSION}; fi
   - if ! [ -z "$MONGODB_VERSION" ]; then pecl install -f mongodb-${MONGODB_VERSION}; fi
   - if ! [ -z "$ADAPTER_VERSION" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
   - composer self-update
+  # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
   - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --ignore-platform-reqs --quiet; fi
   - composer update -v ${COMPOSER_FLAGS}
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Build Status](https://travis-ci.org/doesntmattr/mongodb-migrations-bundle.svg?branch=master)](https://travis-ci.org/doesntmattr/mongodb-migrations-bundle)
+[![Latest Stable Version](https://poser.pugx.org/doesntmattr/mongodb-migrations-bundle/v/stable)](https://packagist.org/packages/doesntmattr/mongodb-migrations-bundle)
+[![Total Downloads](https://poser.pugx.org/doesntmattr/mongodb-migrations-bundle/downloads)](https://packagist.org/packages/doesntmattr/mongodb-migrations-bundle)
+
 :warning: Forked from [antimattr/mongodb-migrations-bundle](https://github.com/antimattr/mongodb-migrations-bundle) for contributors as the original project isn't being maintained. See [issue 16](https://github.com/antimattr/mongodb-migrations/issues/16)
 
 The original authors did an awesome job of making a library that has been really

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PHPUnit\Framework;
+
+$class = 'PHPUnit\Framework\TestCase';
+
+if (!class_exists($class)) {
+
+    abstract class TestCase extends \PHPUnit_Framework_TestCase
+    {
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
         "symfony/http-kernel": "^2.7 || ^3.3 || ^4.0",
         "symfony/console": "^2.7 || ^3.3 || ^4.0",
         "doesntmattr/mongodb-migrations": "^1.1",
-        "doctrine/mongodb-odm": "^1.0",
-        "alcaeus/mongo-php-adapter": "^1.0"
+        "doctrine/mongodb-odm": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "symfony/http-kernel": "^2.7 || ^3.3 || ^4.0",
         "symfony/console": "^2.7 || ^3.3 || ^4.0",
         "doesntmattr/mongodb-migrations": "^1.1",
-        "doctrine/mongodb-odm": "^1.0"
+        "doctrine/mongodb-odm": "^1.0",
+        "alcaeus/mongo-php-adapter": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit colors="true"
+    bootstrap="Tests/bootstrap.php"
+    >
     <testsuites>
         <testsuite name="Doesntmattr MongoDB Migrations Bundle Tests">
             <directory>./Tests/</directory>


### PR DESCRIPTION
### Turn off xdebug
We don't have code coverage and turning off xdebug reduced the build time:

php5.6 4min28sec -> 1min38sec
php7.1 3min12sec -> 2min12sec

### Add cache
Added
```
cache:
    directories:
        - $HOME/.composer/cache/files
```
from http://symfony.com/doc/current/bundles/best_practices.html 

### Other Changes

1. Added php7.2
1. Added README badges
1. Added lowest deps checks
1. Remove unrequired mongodb service