### PR TITLE
Let the ManagerRegistry choose the default DocumentManager

### DIFF
--- a/Command/CommandHelper.php
+++ b/Command/CommandHelper.php
@@ -46,7 +46,7 @@ final class CommandHelper
     }
 
     /**
-     * @param string $dmName
+     * @param null|string $dmName
      */
     public static function setApplicationDocumentManager(Application $application, $dmName): void
     {

--- a/Command/MigrationsExecuteCommand.php
+++ b/Command/MigrationsExecuteCommand.php
@@ -28,7 +28,7 @@ class MigrationsExecuteCommand extends ExecuteCommand
 
         $this
             ->setName('mongodb:migrations:execute')
-            ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.', 'default_document_manager')
+            ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.')
         ;
     }
 

--- a/Command/MigrationsGenerateCommand.php
+++ b/Command/MigrationsGenerateCommand.php
@@ -28,7 +28,7 @@ class MigrationsGenerateCommand extends GenerateCommand
 
         $this
             ->setName('mongodb:migrations:generate')
-            ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.', 'default_document_manager')
+            ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.')
         ;
     }
 

--- a/Command/MigrationsMigrateCommand.php
+++ b/Command/MigrationsMigrateCommand.php
@@ -28,7 +28,7 @@ class MigrationsMigrateCommand extends MigrateCommand
 
         $this
             ->setName('mongodb:migrations:migrate')
-            ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.', 'default_document_manager')
+            ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.')
         ;
     }
 

--- a/Command/MigrationsStatusCommand.php
+++ b/Command/MigrationsStatusCommand.php
@@ -28,7 +28,7 @@ class MigrationsStatusCommand extends StatusCommand
 
         $this
             ->setName('mongodb:migrations:status')
-            ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.', 'default_document_manager')
+            ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.')
         ;
     }
 

--- a/Command/MigrationsVersionCommand.php
+++ b/Command/MigrationsVersionCommand.php
@@ -28,7 +28,7 @@ class MigrationsVersionCommand extends VersionCommand
 
         $this
             ->setName('mongodb:migrations:version')
-            ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.', 'default_document_manager')
+            ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command.')
         ;
     }
 


### PR DESCRIPTION
When option `--dm` is not specified, the bundle tries to retrieve the `DocumentManager` arbitrary named `default_document_manager`.

But this doesn't work when no such `DocumentManager` exist. 
Assuming most of symfony installations use a configuration close to the default one on [symfony documentation](https://symfony.com/doc/master/bundles/DoctrineMongoDBBundle/config.html#multiple-connections), it means that they have a default manager named `default` instead, so this breaks.

The `ManagerRegistry` is already capable of returning the default manager if no name is specified, let's let it handle this.

This PR fixes #32 