### PR TITLE
Symfony 5 support issue

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,12 +28,12 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('mongo_db_migrations', 'array');
         $rootNode    = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('mongo_db_migrations', 'array');
-        
+
         $rootNode
             ->children()
                 ->scalarNode('collection_name')->defaultValue('migration_versions')->cannotBeEmpty()->end()
                 ->scalarNode('database_name')->cannotBeEmpty()->end()
-                ->scalarNode('dir_name')->defaultValue('%kernel.root_dir%/MongoDBMigrations')->cannotBeEmpty()->end()
+                ->scalarNode('dir_name')->defaultValue('%kernel.project_dir%/src/MongoDBMigrations')->cannotBeEmpty()->end()
                 ->scalarNode('name')->defaultValue('Application MongoDB Migrations')->end()
                 ->scalarNode('namespace')->defaultValue('Application\MongoDBMigrations')->cannotBeEmpty()->end()
                 ->scalarNode('script_dir_name')->end()

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Add following configuration lines to `config.yml` file.
 mongo_db_migrations:
     collection_name: "migration_versions"
     database_name: "opensky_devo"
-    dir_name: "%kernel.root_dir%/../src/OpenSky/Bundle/MainBundle/Migrations/MongoDB"
-    script_dir_name: "%kernel.root_dir%/scripts"
+    dir_name: "%kernel.project_dir%/src/OpenSky/Bundle/MainBundle/Migrations/MongoDB"
+    script_dir_name: "%kernel.project_dir%/scripts"
     name: "OpenSky DEVO MongoDB Migrations"
     namespace: "OpenSky\\Bundle\\MainBundle\\MigrationsMongoDB"
 ```


### PR DESCRIPTION
Following the Symfony 5 upgrade changes describe here: https://github.com/symfony/symfony/blob/master/UPGRADE-5.0.md

The `Kernel::getRootDir()` and the `kernel.root_dir` parameter have been removed.

`kernel.root_dir` as been replaced by `kernel.project_dir`