### PR TITLE
fix: remove unsupported MongoDB ODM Bundle ^3.0 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.1",
         "doesntmattr/mongodb-migrations": "^3.0",
-        "doctrine/mongodb-odm-bundle": "^3.0 || ^4.0",
+        "doctrine/mongodb-odm-bundle": "^4.0",
         "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
         "symfony/console": "^3.4 || ^4.0 || ^5.0"
     },


### PR DESCRIPTION
Removes unsupported `doctrine/mongodb-odm-bundle:^3.0` dependency.

Why?
- this bundle relies on `doesntmattr/mongodb-migrations:^3.0` ([link](https://github.com/doesntmattr/mongodb-migrations-bundle/blob/v3.0.1/composer.json#L16))
- `doesntmattr/mongodb-migrations:^3.0` makes use of `DocumentManager::getClient` ([link](https://github.com/doesntmattr/mongodb-migrations/blob/3.0.0/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/AbstractCommand.php#L94))
- `DocumentManager::getClient` [was added in `doctrine/mongodb-odm` 2.x](https://github.com/doctrine/mongodb-odm/commit/7158b08278ab753652f2fec2eacf9d7f236fcffa#diff-c5b64e39a058b30afece06cc7cd217b7R222).
- latest `doctrine/mongodb-odm-bundle` ([v3.6.2](https://packagist.org/packages/doctrine/mongodb-odm-bundle#3.6.2)) only supports `doctrine/mongodb-odm:^1.2`

Ergo this bundle should not have `doctrine/mongodb-odm-bundle:^3.0` as supported dependency, as it will install but fail to work with the following set:

```json
{
  "require": {
    "doesntmattr/mongodb-migrations": "^3.0",
    "doctrine/mongodb-odm-bundle": "^3.6"
  }
}
```

